### PR TITLE
Fix: Typo on WooCommerce name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Order on Mobile for Wocoommerce
+# Order on Mobile for WooCommerce
 
-Order on Mobile for Wocoommerce allows your customers to submit their orders through WhatsApp, directly from the Woocommerce product page.
+Order on Mobile for WooCommerce allows your customers to submit their orders through WhatsApp, directly from the Woocommerce product page.
 
 ## Description
 
@@ -49,7 +49,7 @@ We’d love to hear from you! [plugins@eduardovillao.me](mailto:plugins@eduardov
 
 2. Activate the plugin in WordPress
 
-3. Go to "Order on Mobile for Wocoommerce" admin panel
+3. Go to "Order on Mobile for WooCommerce" admin panel
 
 4. Enter your phone number and other informations
 

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-=== Order on Mobile for Wocoommerce ===
+=== Order on Mobile for WooCommerce ===
 Contributors: evcode
 Donate link: https://eduardovillao.me/
 Tags: woocommerce, whatsapp, order on whatsapp
@@ -9,7 +9,7 @@ Requires PHP: 7.4
 License: GPLv2License
 URI:https://www.gnu.org/licenses/gpl-2.0.html
 
-Order on Mobile for Wocoommerce allows your customers to submit their orders through WhatsApp, directly from the Woocommerce product page.
+Order on Mobile for WooCommerce allows your customers to submit their orders through WhatsApp, directly from the Woocommerce product page.
 
 == Description ==
 
@@ -58,7 +58,7 @@ We’d love to hear from you! [plugins@eduardovillao.me](mailto:plugins@eduardov
 
 2. Activate the plugin in WordPress
 
-3. Go to "Order on Mobile for Wocoommerce" admin panel
+3. Go to "Order on Mobile for WooCommerce" admin panel
 
 4. Enter your phone number and other informations
 
@@ -66,7 +66,7 @@ We’d love to hear from you! [plugins@eduardovillao.me](mailto:plugins@eduardov
 
 == Screenshots ==
 
-1. Order on Mobile for Wocoommerce admin panel
+1. Order on Mobile for WooCommerce admin panel
 
 2. Button in Woocommerce Product Page
 

--- a/woo-order-on-whatsapp.php
+++ b/woo-order-on-whatsapp.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: Order on Mobile for WooCommerce
- * Plugin URI: https://eduardovillao.me/wordpress-plugin/order-on-mobile-for-wocoommerce/
- * Description: Order on Mobile for Wocoommerce allows your customers to submit their orders through WhatsApp, directly from the Woocommerce product page.
+ * Plugin URI: https://eduardovillao.me/wordpress-plugin/order-on-mobile-for-woocommerce/
+ * Description: Order on Mobile for WooCommerce allows your customers to submit their orders through WhatsApp, directly from the Woocommerce product page.
  * Author: EduardoVillao.me
  * Author URI: https://eduardovillao.me/
  * Version: 2.4


### PR DESCRIPTION
This pull request includes several changes to correct the spelling of "WooCommerce" across multiple files in the project documentation and plugin metadata.

Corrections of "WooCommerce" spelling:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R3): Corrected the spelling of "WooCommerce" in the title and description. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R52)
* [`README.txt`](diffhunk://#diff-b01eeed0ec6fc4f4799e44c7b4084e649d6eee4f1aca52ac935553ff82108398L1-R1): Corrected the spelling of "WooCommerce" in the title, description, and admin panel instructions. [[1]](diffhunk://#diff-b01eeed0ec6fc4f4799e44c7b4084e649d6eee4f1aca52ac935553ff82108398L1-R1) [[2]](diffhunk://#diff-b01eeed0ec6fc4f4799e44c7b4084e649d6eee4f1aca52ac935553ff82108398L12-R12) [[3]](diffhunk://#diff-b01eeed0ec6fc4f4799e44c7b4084e649d6eee4f1aca52ac935553ff82108398L61-R69)
* [`woo-order-on-whatsapp.php`](diffhunk://#diff-b60a615fc1951edf3c83f4e3b306ef802977425df9562955243d1871d7cf5c43L4-R5): Corrected the spelling of "WooCommerce" in the plugin name, URI, and description.